### PR TITLE
puppeteer absolute path

### DIFF
--- a/lib/generate.ex
+++ b/lib/generate.ex
@@ -68,7 +68,7 @@ defmodule PuppeteerPdf.Generate do
         exec_path =
           case Application.get_env(:puppeteer_pdf, :exec_path) do
             nil -> "puppeteer-pdf"
-            value -> value
+            value -> Path.absname(value)
           end
 
         params =


### PR DESCRIPTION
When app is deployed in dynamic env, things are not always build in static folder.

Ex: `clever-cloud` or `heroku`