### PR TITLE
Enhance/invalid path

### DIFF
--- a/lib/generate.ex
+++ b/lib/generate.ex
@@ -60,6 +60,7 @@ defmodule PuppeteerPdf.Generate do
   - `landscape` - Paper orientation.
   - `print_background` - Print background graphics.
   - `timeout` - Integer value (ms), configures the timeout of the PDF creation (defaults to 5000)
+  - `wait_until` - :load, :domcontentloaded, :networkidle0, :networkidle2
   """
   @spec from_file(String.t(), String.t(), list()) :: {:ok, String.t()} | {:error, atom()}
   def from_file(html_file_path, pdf_output_path, options \\ []) do
@@ -135,6 +136,13 @@ defmodule PuppeteerPdf.Generate do
                 :height ->
                   must_be_integer("--height", value)
 
+                :wait_until ->
+                  if Enum.member?([:load, :domcontentloaded, :networkidle0, :networkidle2], value) do
+                    ["--waitUntil", Atom.to_string(value)]
+                  else
+                    {:error, :invalid_wait_until_value}
+                  end
+
                 :debug ->
                   ["--debug"]
 
@@ -176,12 +184,23 @@ defmodule PuppeteerPdf.Generate do
             # can hang process. This will assure that it can exit.
             task =
               Task.async(fn ->
-                case System.cmd(exec_path, params) do
-                  {cmd_response, _} ->
-                    {:ok, cmd_response}
+                try do
+                  case System.cmd(exec_path, params) do
+                    {cmd_response, _} ->
+                      {:ok, cmd_response}
 
-                  error_message ->
-                    {:error, error_message}
+                    error_message ->
+                      {:error, error_message}
+                  end
+                rescue
+                  e in ErlangError ->
+                    %ErlangError{original: error} = e
+
+                    case error do
+                      :enoent ->
+                        # This will happen when the file in exec_path doesn't exists
+                        {:error, :invalid_exec_path}
+                    end
                 end
               end)
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule PuppeteerPdf.MixProject do
   def project do
     [
       app: :puppeteer_pdf,
-      version: "1.0.1",
+      version: "1.0.2",
       elixir: "~> 1.6",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,8 @@
 %{
   "briefly": {:hex, :briefly, "0.3.0", "16e6b76d2070ebc9cbd025fa85cf5dbaf52368c4bd896fb482b5a6b95a540c2f", [:mix], []},
-  "earmark": {:hex, :earmark, "1.2.5", "4d21980d5d2862a2e13ec3c49ad9ad783ffc7ca5769cf6ff891a4553fbaae761", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.18.3", "f4b0e4a2ec6f333dccf761838a4b253d75e11f714b85ae271c9ae361367897b7", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, optional: false]}]},
+  "earmark": {:hex, :earmark, "1.3.1", "73812f447f7a42358d3ba79283cfa3075a7580a3a2ed457616d6517ac3738cb9", [:mix], []},
+  "ex_doc": {:hex, :ex_doc, "0.19.3", "3c7b0f02851f5fc13b040e8e925051452e41248f685e40250d7e40b07b9f8c10", [:mix], [{:earmark, "~> 1.2", [hex: :earmark, optional: false]}, {:makeup_elixir, "~> 0.10", [hex: :makeup_elixir, optional: false]}]},
+  "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, optional: false]}]},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, optional: false]}]},
+  "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], []},
 }

--- a/test/puppeteer_pdf_test.exs
+++ b/test/puppeteer_pdf_test.exs
@@ -78,6 +78,20 @@ defmodule PuppeteerPdfTest do
       assert File.exists?(pdf_path) == false
       assert timeout
     end
+
+    test "Handle invalid executable path for puppeteer-pdf" do
+      current_exec_path = Application.get_env(:puppeteer_pdf, :exec_path)
+      :ok = Application.put_env(:puppeteer_pdf, :exec_path, "invalid_path")
+
+      html_value = "<div>Testing 1</div>"
+      pdf_path = "pdf_test.pdf"
+
+      result = PuppeteerPdf.Generate.from_string(html_value, pdf_path)
+
+      :ok = Application.put_env(:puppeteer_pdf, :exec_path, current_exec_path)
+
+      assert {:error, :invalid_exec_path} == result
+    end
   end
 
   test "Check puppeteer-pdf version" do


### PR DESCRIPTION
Improvement to fix #19 
Add wait_until argument already supported by `puppeteer-pdf` NodeJS dependency.