### PR TITLE
Return invalid exec path error when system command returns 127

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ To solve this, you execute the following commands to copy chromium from the `pup
 On OSX and Linux systems should be the following commands:
 
 ```
-npm -i puppeteer -g # This should install chromium
+npm i puppeteer -g # This should install chromium
 cp -R /usr/local/lib/node_modules/puppeteer/.local-chromium/ /usr/local/lib/node_modules/puppeteer-pdf/node_modules/puppeteer/
 ```
 

--- a/lib/generate.ex
+++ b/lib/generate.ex
@@ -186,6 +186,9 @@ defmodule PuppeteerPdf.Generate do
               Task.async(fn ->
                 try do
                   case CommandHelper.cmd(exec_path, params) do
+                    {_, 127} ->
+                      {:error, :invalid_exec_path}
+
                     {cmd_response, _} ->
                       {:ok, cmd_response}
 

--- a/lib/generate.ex
+++ b/lib/generate.ex
@@ -191,9 +191,6 @@ defmodule PuppeteerPdf.Generate do
 
                     {cmd_response, _} ->
                       {:ok, cmd_response}
-
-                    error_message ->
-                      {:error, error_message}
                   end
                 rescue
                   e in ErlangError ->

--- a/lib/puppeteer_pdf.ex
+++ b/lib/puppeteer_pdf.ex
@@ -31,9 +31,6 @@ defmodule PuppeteerPdf do
     case CommandHelper.cmd(exec_path, ["--version"]) do
       {cmd_response, _} ->
         String.replace(cmd_response, "\n", "")
-
-      _error_message ->
-        nil
     end
   end
 


### PR DESCRIPTION
I ran into an issue while running in `circleci`. My `exec_path` wasn't setup correctly but I was still getting an `:ok` because the `ErlangError` wasn't getting raised and it was really hard to figure out what's wrong.

So this pr returns `{:error, :invalid_exec_path}` whenever `System.cmd` returns the error code `127` that means that the command was not found in our `PATH`.

I also deleted some clauses that can never match according to dialyzer and fixed one command in the `README` that was wrong 😄